### PR TITLE
Added Blood Stalk and Grim Swathe Combo features as requested

### DIFF
--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -382,4 +382,57 @@ namespace XIVComboExpandedPlugin.Combos
             return actionID;
         }
     }
+
+    internal class ReaperBloodStalkComboOption : CustomCombo
+    {
+        protected override CustomComboPreset Preset => CustomComboPreset.ReaperBloodSwatheComboFeature;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            var gluttonyCD = GetCooldown(RPR.Gluttony);
+            if (actionID == RPR.BloodStalk)
+            {
+                if (!HasEffect(RPR.Buffs.SoulReaver))
+                {
+                    if ((actionID == RPR.BloodStalk) && !gluttonyCD.IsCooldown && level >= 76)
+                        return RPR.Gluttony;
+                    return RPR.BloodStalk;
+                }
+
+                if (HasEffect(RPR.Buffs.SoulReaver) && (actionID == RPR.BloodStalk || actionID == RPR.Gluttony))
+                {
+                    if (HasEffect(RPR.Buffs.EnhancedGallows) && !HasEffect(RPR.Buffs.Enshrouded))
+                        return RPR.Gallows;
+
+                    return RPR.Gibbet;
+                }
+            }
+            return actionID;
+        }
+    }
+
+    internal class ReaperGrimSwatheComboOption : CustomCombo
+    {
+        protected override CustomComboPreset Preset => CustomComboPreset.ReaperGrimSwatheComboOption;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            var gluttonyCD = GetCooldown(RPR.Gluttony);
+            if (actionID == RPR.GrimSwathe)
+            {
+                if (!HasEffect(RPR.Buffs.SoulReaver))
+                {
+                    if ((actionID == RPR.GrimSwathe) && !gluttonyCD.IsCooldown && level >= 76)
+                        return RPR.Gluttony;
+                    return RPR.GrimSwathe;
+                }
+
+                if (HasEffect(RPR.Buffs.SoulReaver) && (actionID == RPR.GrimSwathe || actionID == RPR.Gluttony))
+                {
+                   return RPR.Guillotine;
+                }
+            }
+            return actionID;
+        }
+    }
 }

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -603,6 +603,12 @@ namespace XIVComboExpandedPlugin
         [CustomComboInfo("Blood Stalk / Grim Swathe Feature", "When Gluttony is off-cooldown, Blood Stalk and Grim Swathe will turn into Gluttony.", RPR.JobID, RPR.BloodStalk, RPR.GrimSwathe)]
         ReaperBloodSwatheFeature = 1712,
 
+        [CustomComboInfo("Blood Stalk Combo Option", "Turns Blood Stalk into Gluttony when off-cooldown and puts Gibbets and Gallows on the same button as Blood Stalk. \n Conflicts with Blood Stalk / Grim Swathe Feature.", RPR.JobID, RPR.BloodStalk)]
+        ReaperBloodSwatheComboFeature = 1713,
+
+        [CustomComboInfo("Grim Swathe Combo Option", "Turns Grim Swathe into Gluttony when off-cooldown and puts Guillotine on the same button as Grim Swathe. \n Conflicts with Blood Stalk / Grim Swathe Feature.", RPR.JobID, RPR.GrimSwathe)]
+        ReaperGrimSwatheComboOption = 1714,
+
         #endregion
         // ====================================================================================
         #region SAGE


### PR DESCRIPTION
Added feature requested in #36 (I think. At least that's what I thought was being requested.) Makes Blood Stalk turn into Gluttony when off-CD and turns into Gibbet/Gallows when used (so all in 1 button). Same with Grim Swathe.

As an aside, I had to build in the GrimSwatheFeature as I figured if people want a 1 button rotation for Blood Stalk -> Gibbet/Gallows they'd want the same for Grim Swathe -> Guillotine. The Feature doesn't differentiate between if the Gluttony is being used for AoE or ST so I had to break it up. So, up to you guys if you want to remove the feature in lieu for the built in option here.